### PR TITLE
feature/MQ2mzTab TMT Support

### DIFF
--- a/MQ2mzTab/misc/MQ2mzTab.R
+++ b/MQ2mzTab/misc/MQ2mzTab.R
@@ -133,30 +133,29 @@ generatePEP<- function(max_quant_peptides) {
          reporter_intensity_columns = column_names[grepl(pattern="Reporter.intensity.[[:digit:]]+", column_names)]
          num_study_variables = length(reporter_intensity_columns)
          intensity_columns = c(max_quant_peptides[reporter_intensity_columns[[1]]], nulls, nulls)
-         
-         for (i in seq(0, num_study_variables - 1, by=1)) {
-             mztab_column_names = c(mztab_column_names, 
-                                    sprintf("peptide_abundance_study_variable[%d]", i),
-                                    sprintf("peptide_abundance_stdev_study_variable[%d]", i),
-                                    sprintf("peptide_abundance_std_error_study_variable[%d]", i))
-              if (i >= 1) {
-                  intensity_columns = c(intensity_columns, 
-                                        max_quant_peptides[reporter_intensity_columns[[i]]], nulls, nulls)
-              }
-        df = data.frame(rep("PEP", nrow(max_quant_peptides)),
-                        max_quant_peptides["Sequence"],
-                        max_quant_peptides["Proteins"],
-                        nulls, nulls, nulls, nulls, 
-                        max_quant_peptides["Score"], nulls, 
-                        max_quant_peptides["Modifications"], 
-                        max_quant_peptides["Retention.time"] * 60,
-                        max_quant_peptides["Retention.length"] * 60,
-                        max_quant_peptides["Charge"], 
-                        max_quant_peptides["m.z"],
-                        nulls,
-                        intensity_columns,
-                        )
 
+         df = data.frame(rep("PEP", nrow(max_quant_peptides)), 
+                         max_quant_peptides["Sequence"], 
+                         max_quant_peptides["Proteins"],
+                         nulls, nulls, nulls, nulls, 
+                         max_quant_peptides["Score"], nulls, 
+                         max_quant_peptides["Modifications"], 
+                         max_quant_peptides["Retention.time"] * 60,
+                         max_quant_peptides["Retention.length"] * 60,
+                         max_quant_peptides["Charge"], 
+                         max_quant_peptides["m.z"],
+                         nulls)
+         
+         for (i in seq(1, num_study_variables, by=1)) {
+             # append intensity columns for each study variable to dataframe
+             column_name = sprintf("peptide_abundance_study_variable[%d]", i)
+             stdev_column_name = sprintf("peptide_abundance_stdev_study_variable[%d]", i)
+             std_error_column_name = sprintf("peptide_abundance_std_error_study_variable[%d]", i)
+             mztab_column_names = c(mztab_column_names, column_name, stdev_column_name,
+                                    std_error_column_name)
+             df[, column_name] = max_quant_peptides[reporter_intensity_columns[[i]]]
+             df[, stdev_column_name] = nulls
+             df[, std_error_column_name] = nulls
          }
 
   } else if (analysis == "Labelfree") {

--- a/MQ2mzTab/misc/MQ2mzTab.R
+++ b/MQ2mzTab/misc/MQ2mzTab.R
@@ -109,7 +109,7 @@ generatePEP<- function(max_quant_peptides) {
                           max_quant_peptides["Retention.time"] * 60,  # minutes to seconds
                           max_quant_peptides["Retention.length"] * 60,  # minutes to seconds
                           max_quant_peptides["Charge"], 
-                          max_quant_peptides["Uncalibrated.m.z"],
+                          max_quant_peptides["m.z"],
                           nulls,
                           max_quant_peptides["Intensity.L"], nulls, nulls,
                           max_quant_peptides["Intensity.H"], nulls, nulls,
@@ -124,12 +124,44 @@ generatePEP<- function(max_quant_peptides) {
                           max_quant_peptides["Retention.time"] * 60,
                           max_quant_peptides["Retention.length"] * 60,
                           max_quant_peptides["Charge"], 
-                          max_quant_peptides["Uncalibrated.m.z"],
+                          max_quant_peptides["m.z"],
                           nulls,
                           max_quant_peptides["Intensity.L"], nulls, nulls,
                           max_quant_peptides["Intensity.H"], nulls, nulls)
       }
-  } else if (analysis == "TMT" || analysis == "Labelfree") {
+  } else if (analysis == "TMT") {
+         reporter_intensity_columns = column_names[grepl(pattern="Reporter.intensity.[[:digit:]]+", column_names)]
+         num_study_variables = length(reporter_intensity_columns)
+         intensity_columns = c(max_quant_peptides[reporter_intensity_columns[[1]]], nulls, nulls)
+         
+         for (i in seq(0, num_study_variables - 1, by=1)) {
+             mztab_column_names = c(mztab_column_names, 
+                                    sprintf("peptide_abundance_study_variable[%d]", i),
+                                    sprintf("peptide_abundance_stdev_study_variable[%d]", i),
+                                    sprintf("peptide_abundance_std_error_study_variable[%d]", i))
+              if (i >= 1) {
+                  intensity_columns = c(intensity_columns, 
+                                        max_quant_peptides[reporter_intensity_columns[[i]]], nulls, nulls)
+              }
+        df = data.frame(rep("PEP", nrow(max_quant_peptides)),
+                        max_quant_peptides["Sequence"],
+                        max_quant_peptides["Proteins"],
+                        nulls, nulls, nulls, nulls, 
+                        max_quant_peptides["Score"], nulls, 
+                        max_quant_peptides["Modifications"], 
+                        max_quant_peptides["Retention.time"] * 60,
+                        max_quant_peptides["Retention.length"] * 60,
+                        max_quant_peptides["Charge"], 
+                        max_quant_peptides["m.z"],
+                        nulls,
+                        intensity_columns,
+                        )
+
+         }
+
+  } else if (analysis == "Labelfree") {
+          # Labelfree not yet supported, needs linking of evidence.txt with peptides.txt
+          # we simply use random numbers for the intensities here.
           mztab_column_names = c(mztab_column_names, 
                              "peptide_abundance_study_variable[1]", 
                              "peptide_abundance_stdev_study_variable[1]", 
@@ -143,13 +175,15 @@ generatePEP<- function(max_quant_peptides) {
                           max_quant_peptides["Retention.time"] * 60,
                           max_quant_peptides["Retention.length"] * 60,
                           max_quant_peptides["Charge"], 
-                          max_quant_peptides["Uncalibrated.m.z"],
+                          max_quant_peptides["m.z"],
                           nulls,
                           # max_quant_peptides["Intensities"], 
                           # NOTE: Currently we use random numbers here, because it is unclear
                           # where to obtain the actual intensities.
                           runif(nrow(max_quant_peptides), min=0, max=5000),
                           nulls, nulls)
+
+
   }
 
   # Overwrite column names with correct ones.
@@ -210,8 +244,8 @@ checkMaxQuantFolder(input.folder)
 
 #  Generate PEP section {{{ # 
 
-allPeptides_file = file.path(input.folder, "allPeptides.txt")
-max_quant_peptides = read.table(allPeptides_file, sep="\t", header=TRUE, stringsAsFactors=FALSE, na.strings=c("", "NA", " ", "  "))
+evidence_file = file.path(input.folder, "evidence.txt")
+max_quant_peptides = read.table(evidence_file, sep="\t", header=TRUE, stringsAsFactors=FALSE, na.strings=c("", "NA", " ", "  "))
 
 analyis_type = analysisType(colnames(max_quant_peptides))
 

--- a/MQ2mzTab/misc/MQ2mzTab.R
+++ b/MQ2mzTab/misc/MQ2mzTab.R
@@ -148,9 +148,11 @@ generatePEP<- function(max_quant_peptides) {
          
          for (i in seq(1, num_study_variables, by=1)) {
              # append intensity columns for each study variable to dataframe
-             column_name = sprintf("peptide_abundance_study_variable[%d]", i)
-             stdev_column_name = sprintf("peptide_abundance_stdev_study_variable[%d]", i)
-             std_error_column_name = sprintf("peptide_abundance_std_error_study_variable[%d]", i)
+             # use i - 1 to maintain matching names of reporter.intensity columns
+             # (they start from 0!)
+             column_name = sprintf("peptide_abundance_study_variable[%d]", i - 1)
+             stdev_column_name = sprintf("peptide_abundance_stdev_study_variable[%d]", i - 1)
+             std_error_column_name = sprintf("peptide_abundance_std_error_study_variable[%d]", i - 1)
              mztab_column_names = c(mztab_column_names, column_name, stdev_column_name,
                                     std_error_column_name)
              df[, column_name] = max_quant_peptides[reporter_intensity_columns[[i]]]

--- a/mzTab2report/mzTab2report.Snw
+++ b/mzTab2report/mzTab2report.Snw
@@ -293,21 +293,25 @@ The {\tt PEP} section of the {\tt mzTab} file contains $\Sexpr{format(n.peptides
 \centering
 \vspace{-1cm}
 \subfloat[peptide abundances 3, $\operatorname{median}(\operatorname{intensity}) = \Sexpr{format(median.abundance.3, big.mark=",")}$]{\includegraphics[width=\FigureWidthA]{plot_DistributionIntensity_3.pdf}}\\
-}
-{}
 \caption{peptide abundance distributions.}
 \end{figure}
+}
+{}
 
 
 %
 % Kendrick nominal-fractional mass plot
 %
 
+\IfFileExists{plot_DistributionIntensity_3.pdf}
+{
 \begin{figure}[hb]
 \centering
 \includegraphics[width=10.0cm]{plot_Kendrick.pdf}
 \caption{Kendrick nominal fractional mass plot}
 \end{figure}
+}
+{}
 
 
 %

--- a/mzTab2report/mzTab2report.Snw
+++ b/mzTab2report/mzTab2report.Snw
@@ -293,25 +293,21 @@ The {\tt PEP} section of the {\tt mzTab} file contains $\Sexpr{format(n.peptides
 \centering
 \vspace{-1cm}
 \subfloat[peptide abundances 3, $\operatorname{median}(\operatorname{intensity}) = \Sexpr{format(median.abundance.3, big.mark=",")}$]{\includegraphics[width=\FigureWidthA]{plot_DistributionIntensity_3.pdf}}\\
-\caption{peptide abundance distributions.}
-\end{figure}
 }
 {}
+\caption{peptide abundance distributions.}
+\end{figure}
 
 
 %
 % Kendrick nominal-fractional mass plot
 %
 
-\IfFileExists{plot_DistributionIntensity_3.pdf}
-{
 \begin{figure}[hb]
 \centering
 \includegraphics[width=10.0cm]{plot_Kendrick.pdf}
 \caption{Kendrick nominal fractional mass plot}
 \end{figure}
-}
-{}
 
 
 %

--- a/mzTab2report/mzTab2report.bat
+++ b/mzTab2report/mzTab2report.bat
@@ -45,6 +45,12 @@ rem  replace dummy FILE_NAME_DUMMY by file name %FILE_BASE%
 rem  Run the R code
 R -e "Sweave('mzTab2report_temp.Snw')"
 
+rem If sweave fails, exit with error code.
+if %errorlevel% neq 0 (
+    ECHO "Sweave encountered an error! Exiting."
+    exit \b %errorlevel%
+)
+
 rem Small 5 sec pause.
 timeout /t 5 /NOBREAK
 


### PR DESCRIPTION
This pull request provides (tested, on ubuntu and windows) support to add intensity columns 
for TMT files. To this end, we use `Report.intensity` columns found in MaxQuant's `evidence.txt` and turn them into `"peptide_abundance_study_variable[i]"` columns in our `mzTab` output file.
This concludes our roadmap towards TMT support -- TMT files and labelled files are now supported by our exporter.