### PR TITLE
sec -> min in MQ2mzTab retention time

### DIFF
--- a/MQ2mzTab/misc/MQ2mzTab.R
+++ b/MQ2mzTab/misc/MQ2mzTab.R
@@ -106,8 +106,8 @@ generatePEP<- function(max_quant_peptides) {
                           nulls, nulls, nulls, nulls, 
                           max_quant_peptides["Score"], nulls, 
                           max_quant_peptides["Modifications"], 
-                          max_quant_peptides["Retention.time"] * 60,  # minutes to seconds
-                          max_quant_peptides["Retention.length"] * 60,  # minutes to seconds
+                          max_quant_peptides["Retention.time"],  # minutes to seconds
+                          max_quant_peptides["Retention.length"],  # minutes to seconds
                           max_quant_peptides["Charge"], 
                           max_quant_peptides["m.z"],
                           nulls,
@@ -121,8 +121,8 @@ generatePEP<- function(max_quant_peptides) {
                           nulls, nulls, nulls, nulls, 
                           max_quant_peptides["Score"], nulls, 
                           max_quant_peptides["Modifications"], 
-                          max_quant_peptides["Retention.time"] * 60,
-                          max_quant_peptides["Retention.length"] * 60,
+                          max_quant_peptides["Retention.time"],
+                          max_quant_peptides["Retention.length"],
                           max_quant_peptides["Charge"], 
                           max_quant_peptides["m.z"],
                           nulls,
@@ -140,8 +140,8 @@ generatePEP<- function(max_quant_peptides) {
                          nulls, nulls, nulls, nulls, 
                          max_quant_peptides["Score"], nulls, 
                          max_quant_peptides["Modifications"], 
-                         max_quant_peptides["Retention.time"] * 60,
-                         max_quant_peptides["Retention.length"] * 60,
+                         max_quant_peptides["Retention.time"],
+                         max_quant_peptides["Retention.length"],
                          max_quant_peptides["Charge"], 
                          max_quant_peptides["m.z"],
                          nulls)
@@ -173,8 +173,8 @@ generatePEP<- function(max_quant_peptides) {
                           nulls, nulls, nulls, nulls, 
                           max_quant_peptides["Score"], nulls, 
                           max_quant_peptides["Modifications"], 
-                          max_quant_peptides["Retention.time"] * 60,
-                          max_quant_peptides["Retention.length"] * 60,
+                          max_quant_peptides["Retention.time"],
+                          max_quant_peptides["Retention.length"],
                           max_quant_peptides["Charge"], 
                           max_quant_peptides["m.z"],
                           nulls,


### PR DESCRIPTION
It appears as though we need retention time in seconds rather than minutes for MQ2mzTab. This pull request undoes the conversion.